### PR TITLE
Track LLM token consumption and expose via INFO response field

### DIFF
--- a/src/Flussu/Api/Ai/FlussuClaudeAi.php
+++ b/src/Flussu/Api/Ai/FlussuClaudeAi.php
@@ -82,7 +82,16 @@ class FlussuClaudeAi implements IAiProvider
             //Log::error("Claude API Error: " . $e->getMessage());
             return "Error: no response. Details: " . $e->getMessage();
         }
-        $resChat=[$sendArray,$response->getContent()[0]['text']];
+        // Extract token usage if available
+        $tokenUsage = null;
+        if (method_exists($response, 'getUsage')) {
+            $usage = $response->getUsage();
+            $tokenUsage = [
+                'input' => $usage['input_tokens'] ?? 0,
+                'output' => $usage['output_tokens'] ?? 0
+            ];
+        }
+        $resChat=[$sendArray, $response->getContent()[0]['text'], $tokenUsage];
         return $resChat;
     }
 

--- a/src/Flussu/Api/Ai/FlussuDeepSeekAi.php
+++ b/src/Flussu/Api/Ai/FlussuDeepSeekAi.php
@@ -81,7 +81,15 @@ class FlussuDeepSeekAi implements IAiProvider
             return "Error: no response. Details: " . $e->getMessage();
         }
         $res=json_decode($result, true);
-        return [$arrayText,($res["choices"][0]["message"]["content"] ?? "Error: no DeepSeek response. Details: " . $result)];
+        // Extract token usage if available
+        $tokenUsage = null;
+        if (isset($res["usage"])) {
+            $tokenUsage = [
+                'input' => $res["usage"]["prompt_tokens"] ?? 0,
+                'output' => $res["usage"]["completion_tokens"] ?? 0
+            ];
+        }
+        return [$arrayText, ($res["choices"][0]["message"]["content"] ?? "Error: no DeepSeek response. Details: " . $result), $tokenUsage];
     }
 
     function chat_WebPreview($sendText,$session="123-231-321",$max_output_tokens=150,$temperature=0.7){

--- a/src/Flussu/Api/Ai/FlussuGeminAi.php
+++ b/src/Flussu/Api/Ai/FlussuGeminAi.php
@@ -84,6 +84,7 @@ class FlussuGeminAi implements IAiProvider
             );
         }, $oldMsgArray);
 
+        $tokenUsage = null;
         try {
             // Inizializza la chat con la cronologia
             $chat = $this->_gemini->generativeModel($this->_gemini_chat_model)->startChat($history);
@@ -92,12 +93,21 @@ class FlussuGeminAi implements IAiProvider
             // Invia il nuovo messaggio
             $response = $chat->sendMessage($sendText);
             $responseText=$response->text();
+            // Extract token usage if available
+            if (method_exists($response, 'usageMetadata') && $response->usageMetadata()) {
+                $usage = $response->usageMetadata();
+                $tokenUsage = [
+                    'input' => $usage->promptTokenCount ?? 0,
+                    'output' => $usage->candidatesTokenCount ?? 0
+                ];
+            }
         } catch (\Throwable $e) {
             $responseText="Error: no response. Details: " . $e->getMessage();
         }
         return [
             $oldMsgArray,
-            $responseText
+            $responseText,
+            $tokenUsage
         ];
 
     }

--- a/src/Flussu/Api/Ai/FlussuHuggingFaceAi.php
+++ b/src/Flussu/Api/Ai/FlussuHuggingFaceAi.php
@@ -105,21 +105,22 @@ class FlussuHuggingFaceAi implements IAiProvider
             // Estrai ultimo messaggio utente
             $lastMessage = end($sendArray);
             $textToProcess = $lastMessage['content'];
-            
+
             // Determina il tipo di task in base al modello
             $taskType = $this->_getTaskType($this->_hf_model);
-            
+
             // Esegui richiesta API
             $response = $this->_callHuggingFaceAPI($textToProcess, $taskType);
-            
+
             // Formatta risposta
             $responseText = $this->_formatResponse($response, $taskType);
-            
-            return [$sendArray, $responseText];
-            
+
+            // HuggingFace Inference API doesn't return token usage
+            return [$sendArray, $responseText, null];
+
         } catch (\Throwable $e) {
             //Log::error("Hugging Face API Error: " . $e->getMessage());
-            return [$sendArray, "Error: " . $e->getMessage()];
+            return [$sendArray, "Error: " . $e->getMessage(), null];
         }
     }
 

--- a/src/Flussu/Api/Ai/FlussuOpenAi.php
+++ b/src/Flussu/Api/Ai/FlussuOpenAi.php
@@ -114,7 +114,15 @@ class FlussuOpenAi implements IAiProvider
         } catch (\Throwable $e) {
             return "Error: no response. Details: " . $e->getMessage();
         }
-        return [$arrayText,$result->choices[0]->message->content]; 
+        // Extract token usage if available
+        $tokenUsage = null;
+        if (isset($result->usage)) {
+            $tokenUsage = [
+                'input' => $result->usage->promptTokens ?? 0,
+                'output' => $result->usage->completionTokens ?? 0
+            ];
+        }
+        return [$arrayText, $result->choices[0]->message->content, $tokenUsage];
     }
 
     function chat_WebPreview($sendText,$session="123-231-321",$max_output_tokens=150,$temperature=0.7){

--- a/src/Flussu/Api/V40/Engine.php
+++ b/src/Flussu/Api/V40/Engine.php
@@ -453,6 +453,13 @@ class Engine {
                 "bid"=>$frmBid,
                 "elms"=>$frmElms
             ];
+            // V4.5.2 - Include INFO in response if present in session, then clear it
+            $infoValue = $wSess->getVarValue('$INFO');
+            if (!empty($infoValue)) {
+                $res["info"] = $infoValue;
+                // Clear INFO from session after sending
+                $wSess->assignVars('$INFO', '');
+            }
         }
         return $res;
     }

--- a/src/Flussu/Flussuserver/Executor.php
+++ b/src/Flussu/Flussuserver/Executor.php
@@ -320,8 +320,17 @@ class Executor{
                             $Sess->statusError(true);
                             //$reslt[1]="[ERROR]";
                             //break;
-                        } 
+                        }
                         $Sess->assignVars($innerParams[2],$reslt[1]);
+                        // V4.5.2 - Track LLM token consumption in INFO session variable
+                        if (isset($reslt[2]) && is_array($reslt[2])) {
+                            $tokenInfo = [
+                                'CTI' => $reslt[2]['input'] ?? 0,
+                                'CTO' => $reslt[2]['output'] ?? 0
+                            ];
+                            $Sess->assignVars('$INFO', json_encode($tokenInfo));
+                            $Sess->recLog("AI tokens - IN: ".$tokenInfo['CTI']." OUT: ".$tokenInfo['CTO']);
+                        }
                         break;
                 /*
                     case "openAi":


### PR DESCRIPTION
Add token tracking across all AI providers (OpenAI, Claude, Gemini, DeepSeek, Grok, HuggingFace) by returning input/output token counts from chat methods. Token data (CTI/CTO) is stored in session $INFO variable and included in API response, then cleared after sending.