### PR TITLE
Simplify sendToAi switch to use Platform enum directly

### DIFF
--- a/src/Flussu/Flussuserver/Executor.php
+++ b/src/Flussu/Flussuserver/Executor.php
@@ -297,23 +297,9 @@ class Executor{
                         $Sess->statusCallExt(true);
                         $Sess->recLog("AI provider: ".$innerParams[0]);
                         $Sess->recLog("call AI: ".$innerParams[1]);
-                        switch  ($innerParams[0]){
-                            case 1:
-                                $ctrl=new AiChatController(Platform::GROK);
-                                break;
-                            case 2:
-                                $ctrl=new AiChatController(Platform::GEMINI);
-                                break;
-                            case 3:
-                                $ctrl=new AiChatController(Platform::DEEPSEEK);
-                                break;
-                            case 4:
-                                $ctrl=new AiChatController(Platform::CLAUDE);
-                                break;
-                            default:
-                                $ctrl=new AiChatController(Platform::CHATGPT);
-                                break;
-                        }
+                        // Use Platform enum directly from numeric value, fallback to CHATGPT if invalid
+                        $platform = Platform::tryFrom((int)$innerParams[0]) ?? Platform::CHATGPT;
+                        $ctrl = new AiChatController($platform);
                         $reslt=$ctrl->chat($Sess->getId(), $innerParams[1]);
                         if ($reslt[0]!="Ok"){
                             $Sess->recLog("AI response: ".json_encode($reslt[1]));


### PR DESCRIPTION
Replace manual switch statement with Platform::tryFrom() to convert numeric value to enum, with CHATGPT fallback for invalid values. This supports all AI providers automatically and is more maintainable.

https://claude.ai/code/session_01YQH4qkcXWrCk5c2AY6GXpY