### PR TITLE
Extract Platform enum to separate file

### DIFF
--- a/src/Flussu/Controllers/AiChatController.php
+++ b/src/Flussu/Controllers/AiChatController.php
@@ -41,18 +41,7 @@ use Flussu\Api\Ai\FlussuZeroOneAi;
 use Flussu\Api\Ai\FlussuKimiAi;
 use Flussu\Api\Ai\FlussuQwenAi;
 use Log;
-enum Platform: int {
-    case INIT = -1;
-    case CHATGPT = 0;
-    case GROK = 1;
-    case GEMINI = 2;
-    case DEEPSEEK = 3;
-    case CLAUDE = 4;
-    case HUGGINGFACE = 5;
-    case ZEROONE = 6;
-    case KIMI = 7;
-    case QWEN = 8;
-}
+
 class AiChatController 
 {
     private $_linkify=0;

--- a/src/Flussu/Controllers/Platform.php
+++ b/src/Flussu/Controllers/Platform.php
@@ -1,0 +1,30 @@
+<?php
+/* --------------------------------------------------------------------*
+ * Flussu v4.5- Mille Isole SRL - Released under Apache License 2.0
+ * --------------------------------------------------------------------*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * --------------------------------------------------------------------*/
+namespace Flussu\Controllers;
+
+enum Platform: int {
+    case INIT = -1;
+    case CHATGPT = 0;
+    case GROK = 1;
+    case GEMINI = 2;
+    case DEEPSEEK = 3;
+    case CLAUDE = 4;
+    case HUGGINGFACE = 5;
+    case ZEROONE = 6;
+    case KIMI = 7;
+    case QWEN = 8;
+}


### PR DESCRIPTION
Moved the Platform enum from AiChatController.php to its own file (Platform.php) to fix autoloading issues. The enum was not being found by other classes like Executor.php because it was defined inline within AiChatController.php.

https://claude.ai/code/session_01GqNABf9WjbTmmAZm6zF8bK