### PR TITLE
Fix AI providers: apply chat model in API calls and fix message norma…

### DIFF
--- a/src/Flussu/Api/Ai/FlussuClaudeAi.php
+++ b/src/Flussu/Api/Ai/FlussuClaudeAi.php
@@ -62,12 +62,13 @@ class FlussuClaudeAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]); 
+                unset($message["message"]);
             }
         }
+        unset($message);
         $preChat[]= [
             'role' => $role,
             'content' => $sendText,
@@ -77,7 +78,10 @@ class FlussuClaudeAi implements IAiProvider
 
     private function _chatContinue($sendArray){
         try{
-            $response = $this->_claude3->chat($sendArray);
+            $response = $this->_claude3->chat([
+                'model' => $this->_claude_chat_model,
+                'messages' => $sendArray
+            ]);
         } catch (\Throwable $e) {
             //Log::error("Claude API Error: " . $e->getMessage());
             return "Error: no response. Details: " . $e->getMessage();

--- a/src/Flussu/Api/Ai/FlussuDeepSeekAi.php
+++ b/src/Flussu/Api/Ai/FlussuDeepSeekAi.php
@@ -60,12 +60,13 @@ class FlussuDeepSeekAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]); 
+                unset($message["message"]);
             }
         }
+        unset($message);
         $preChat[]= [
             'role' => $role,
             'content' => $sendText,
@@ -75,7 +76,7 @@ class FlussuDeepSeekAi implements IAiProvider
 
     private function _chatContinue($arrayText){
         try{
-            $result = $this->_deepseek->query(json_encode(["messages"=>$arrayText]))->run();
+            $result = $this->_deepseek->query(json_encode(["messages"=>$arrayText]))->withModel($this->_deepseek_chat_model)->run();
         } catch (\Throwable $e) {
             //Log::error("Claude API Error: " . $e->getMessage());
             return "Error: no response. Details: " . $e->getMessage();
@@ -85,7 +86,7 @@ class FlussuDeepSeekAi implements IAiProvider
         $tokenUsage = null;
         if (isset($res["usage"])) {
             $tokenUsage = [
-                'model' => $this->_deepseek_model,
+                'model' => $this->_deepseek_chat_model,
                 'input' => $res["usage"]["prompt_tokens"] ?? 0,
                 'output' => $res["usage"]["completion_tokens"] ?? 0
             ];

--- a/src/Flussu/Api/Ai/FlussuGeminAi.php
+++ b/src/Flussu/Api/Ai/FlussuGeminAi.php
@@ -63,12 +63,13 @@ class FlussuGeminAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]); 
+                unset($message["message"]);
             }
         }
+        unset($message);
         return $this->_chatContinue($preChat,$sendText,$role);
     }
 

--- a/src/Flussu/Api/Ai/FlussuKimiAi.php
+++ b/src/Flussu/Api/Ai/FlussuKimiAi.php
@@ -62,12 +62,13 @@ class FlussuKimiAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]);
+                unset($message["message"]);
             }
         }
+        unset($message);
         $preChat[]= [
             'role' => $role,
             'content' => $sendText,
@@ -77,7 +78,7 @@ class FlussuKimiAi implements IAiProvider
 
     private function _chatContinue($arrayText){
         $payload = [
-            'model' => $this->_kimi_ai_model,
+            'model' => $this->_kimi_chat_model,
             'messages' => $arrayText
             //,'max_tokens' => 2000
         ];
@@ -101,7 +102,7 @@ class FlussuKimiAi implements IAiProvider
             $tokenUsage = null;
             if (isset($data['usage'])) {
                 $tokenUsage = [
-                    'model' => $this->_kimi_ai_model,
+                    'model' => $this->_kimi_chat_model,
                     'input' => $data['usage']['prompt_tokens'] ?? 0,
                     'output' => $data['usage']['completion_tokens'] ?? 0
                 ];

--- a/src/Flussu/Api/Ai/FlussuOpenAi.php
+++ b/src/Flussu/Api/Ai/FlussuOpenAi.php
@@ -84,12 +84,13 @@ class FlussuOpenAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]); 
+                unset($message["message"]);
             }
         }
+        unset($message);
         $preChat[]= [
             'role' => $role,
             'content' => $sendText,

--- a/src/Flussu/Api/Ai/FlussuQwenAi.php
+++ b/src/Flussu/Api/Ai/FlussuQwenAi.php
@@ -62,12 +62,13 @@ class FlussuQwenAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]);
+                unset($message["message"]);
             }
         }
+        unset($message);
         $preChat[]= [
             'role' => $role,
             'content' => $sendText,
@@ -77,7 +78,7 @@ class FlussuQwenAi implements IAiProvider
 
     private function _chatContinue($arrayText){
         $payload = [
-            'model' => $this->_qwen_ai_model,
+            'model' => $this->_qwen_chat_model,
             'messages' => $arrayText,
             'max_tokens' => 2000
         ];
@@ -101,7 +102,7 @@ class FlussuQwenAi implements IAiProvider
             $tokenUsage = null;
             if (isset($data['usage'])) {
                 $tokenUsage = [
-                    'model' => $this->_qwen_ai_model,
+                    'model' => $this->_qwen_chat_model,
                     'input' => $data['usage']['prompt_tokens'] ?? 0,
                     'output' => $data['usage']['completion_tokens'] ?? 0
                 ];

--- a/src/Flussu/Api/Ai/FlussuZeroOneAi.php
+++ b/src/Flussu/Api/Ai/FlussuZeroOneAi.php
@@ -62,12 +62,13 @@ class FlussuZeroOneAi implements IAiProvider
     }
 
     function chat($preChat,$sendText,$role="user"){
-        foreach ($preChat as $message) {
+        foreach ($preChat as &$message) {
             if (isset($message["message"]) && !isset($message["content"])) {
                 $message["content"] = $message["message"];
-                unset($message["content"]);
+                unset($message["message"]);
             }
         }
+        unset($message);
         $preChat[]= [
             'role' => $role,
             'content' => $sendText,
@@ -77,7 +78,7 @@ class FlussuZeroOneAi implements IAiProvider
 
     private function _chatContinue($arrayText){
         $payload = [
-            'model' => $this->_zeroone_ai_model,
+            'model' => $this->_zeroone_chat_model,
             'messages' => $arrayText,
             'max_tokens' => 2000
         ];
@@ -101,7 +102,7 @@ class FlussuZeroOneAi implements IAiProvider
             $tokenUsage = null;
             if (isset($data['usage'])) {
                 $tokenUsage = [
-                    'model' => $this->_zeroone_ai_model,
+                    'model' => $this->_zeroone_chat_model,
                     'input' => $data['usage']['prompt_tokens'] ?? 0,
                     'output' => $data['usage']['completion_tokens'] ?? 0
                 ];


### PR DESCRIPTION
…lization

Three bugs fixed across all AI provider classes:

1. Model not applied during chat execution: Claude, DeepSeek, Qwen, Kimi, and ZeroOne were not passing the configured chat model to their respective API calls. Grok lacked chat_model support entirely.

2. foreach by-value instead of by-reference: the message normalization loop used `foreach ($preChat as $message)` which copies each element, so changes to $message never propagated back to $preChat.

3. Wrong unset target: `unset($message["content"])` immediately deleted the field that was just assigned, instead of `unset($message["message"])`.

https://claude.ai/code/session_0163tA8fZwhB9Pp3s5e54XtU