### PR TITLE
Add API key validation for Kimi and Qwen providers

### DIFF
--- a/src/Flussu/Api/Ai/FlussuKimiAi.php
+++ b/src/Flussu/Api/Ai/FlussuKimiAi.php
@@ -29,7 +29,6 @@ use Flussu\Contracts\IAiProvider;
 class FlussuKimiAi implements IAiProvider
 {
     private $_aiErrorState=false;
-    private $_kimi_ai;
     private $_kimi_ai_key="";
     private $_kimi_ai_model="";
     private $_kimi_chat_model="";
@@ -40,25 +39,33 @@ class FlussuKimiAi implements IAiProvider
     }
 
     public function __construct($model="", $chat_model=""){
-        if (!isset($this->_kimi_ai)){
-            $this->_kimi_ai_key = config("services.ai_provider.kimi.auth_key");
-            if ($model)
-                $this->_kimi_ai_model = $model;
-            else {
-                if (!empty(config("services.ai_provider.kimi.model")))
-                    $this->_kimi_ai_model=config("services.ai_provider.kimi.model");
-            }
-            if ($chat_model)
-                $this->_kimi_chat_model = $chat_model;
-            else {
-                if (!empty(config("services.ai_provider.kimi.chat-model")))
-                    $this->_kimi_chat_model=config("services.ai_provider.kimi.chat-model");
-            }
-            $this->client = new Client([
-                'base_uri' => 'https://api.moonshot.cn/v1/',
-                'timeout'  => 10.0,
-            ]);
+        $this->_kimi_ai_key = config("services.ai_provider.kimi.auth_key");
+
+        // Validate API key is present and not a placeholder
+        if (empty($this->_kimi_ai_key)) {
+            throw new Exception("Kimi (Moonshot) API key not configured. Please set 'services.ai_provider.kimi.auth_key' in config/.services.json");
         }
+        if (strpos($this->_kimi_ai_key, 'insert-your-api-key') !== false ||
+            strpos($this->_kimi_ai_key, '6768-insert') !== false) {
+            throw new Exception("Kimi (Moonshot) API key is still set to placeholder value. Please configure your actual API key in config/.services.json");
+        }
+
+        if ($model)
+            $this->_kimi_ai_model = $model;
+        else {
+            if (!empty(config("services.ai_provider.kimi.model")))
+                $this->_kimi_ai_model=config("services.ai_provider.kimi.model");
+        }
+        if ($chat_model)
+            $this->_kimi_chat_model = $chat_model;
+        else {
+            if (!empty(config("services.ai_provider.kimi.chat-model")))
+                $this->_kimi_chat_model=config("services.ai_provider.kimi.chat-model");
+        }
+        $this->client = new Client([
+            'base_uri' => 'https://api.moonshot.cn/v1/',
+            'timeout'  => 10.0,
+        ]);
     }
 
     function chat($preChat,$sendText,$role="user"){

--- a/src/Flussu/Api/Ai/FlussuQwenAi.php
+++ b/src/Flussu/Api/Ai/FlussuQwenAi.php
@@ -29,7 +29,6 @@ use Flussu\Contracts\IAiProvider;
 class FlussuQwenAi implements IAiProvider
 {
     private $_aiErrorState=false;
-    private $_qwen_ai;
     private $_qwen_ai_key="";
     private $_qwen_ai_model="";
     private $_qwen_chat_model="";
@@ -40,25 +39,33 @@ class FlussuQwenAi implements IAiProvider
     }
 
     public function __construct($model="", $chat_model=""){
-        if (!isset($this->_qwen_ai)){
-            $this->_qwen_ai_key = config("services.ai_provider.qwen.auth_key");
-            if ($model)
-                $this->_qwen_ai_model = $model;
-            else {
-                if (!empty(config("services.ai_provider.qwen.model")))
-                    $this->_qwen_ai_model=config("services.ai_provider.qwen.model");
-            }
-            if ($chat_model)
-                $this->_qwen_chat_model = $chat_model;
-            else {
-                if (!empty(config("services.ai_provider.qwen.chat-model")))
-                    $this->_qwen_chat_model=config("services.ai_provider.qwen.chat-model");
-            }
-            $this->client = new Client([
-                'base_uri' => 'https://dashscope.aliyuncs.com/compatible-mode/v1/',
-                'timeout'  => 10.0,
-            ]);
+        $this->_qwen_ai_key = config("services.ai_provider.qwen.auth_key");
+
+        // Validate API key is present and not a placeholder
+        if (empty($this->_qwen_ai_key)) {
+            throw new Exception("Qwen (Alibaba) API key not configured. Please set 'services.ai_provider.qwen.auth_key' in config/.services.json");
         }
+        if (strpos($this->_qwen_ai_key, 'insert-your-api-key') !== false ||
+            strpos($this->_qwen_ai_key, '6768-insert') !== false) {
+            throw new Exception("Qwen (Alibaba) API key is still set to placeholder value. Please configure your actual API key in config/.services.json");
+        }
+
+        if ($model)
+            $this->_qwen_ai_model = $model;
+        else {
+            if (!empty(config("services.ai_provider.qwen.model")))
+                $this->_qwen_ai_model=config("services.ai_provider.qwen.model");
+        }
+        if ($chat_model)
+            $this->_qwen_chat_model = $chat_model;
+        else {
+            if (!empty(config("services.ai_provider.qwen.chat-model")))
+                $this->_qwen_chat_model=config("services.ai_provider.qwen.chat-model");
+        }
+        $this->client = new Client([
+            'base_uri' => 'https://dashscope.aliyuncs.com/compatible-mode/v1/',
+            'timeout'  => 10.0,
+        ]);
     }
 
     function chat($preChat,$sendText,$role="user"){


### PR DESCRIPTION
Adds early validation to throw clear error messages when API keys are missing or still set to placeholder values, instead of getting cryptic 401 authentication errors from the APIs.

https://claude.ai/code/session_01CCgt3dsn4mSPWuFyza7xoD