### PR TITLE
Fix Gemini token extraction: access usageMetadata as property, not me…

### DIFF
--- a/src/Flussu/Api/Ai/FlussuGeminAi.php
+++ b/src/Flussu/Api/Ai/FlussuGeminAi.php
@@ -100,8 +100,9 @@ class FlussuGeminAi implements IAiProvider
             $response = $chat->sendMessage($sendText);
             $responseText=$response->text();
             // Extract token usage if available
-            if (method_exists($response, 'usageMetadata') && $response->usageMetadata()) {
-                $usage = $response->usageMetadata();
+            // usageMetadata is a property (not a method) in google-gemini-php/client v2
+            if (isset($response->usageMetadata)) {
+                $usage = $response->usageMetadata;
                 $tokenUsage = [
                     'model' => $this->_gemini_chat_model,
                     'input' => $usage->promptTokenCount ?? 0,
@@ -148,8 +149,9 @@ class FlussuGeminAi implements IAiProvider
 
             $responseText = $response->text();
 
-            if (method_exists($response, 'usageMetadata') && $response->usageMetadata()) {
-                $usage = $response->usageMetadata();
+            // usageMetadata is a property (not a method) in google-gemini-php/client v2
+            if (isset($response->usageMetadata)) {
+                $usage = $response->usageMetadata;
                 $tokenUsage = [
                     'model' => $this->_gemini_chat_model,
                     'input' => $usage->promptTokenCount ?? 0,


### PR DESCRIPTION
…thod

In google-gemini-php/client v2, usageMetadata is a public property on GenerateContentResponse, not a method. The code was using method_exists() and calling usageMetadata() as a method, which silently failed and returned null token counts for all Gemini API calls.

Fixed in both chat() and analyzeMedia() methods.

https://claude.ai/code/session_018oXJRszc5tvEVDF5DqMKQd