### PR TITLE
Add LLM model variants to Platform enum (family numbering)

### DIFF
--- a/config/.services.json.sample
+++ b/config/.services.json.sample
@@ -46,16 +46,19 @@
       "open_ai":{
         "auth_key":"6768-insert-your-api-key-8768",
         "model":"o1-mini",
-        "chat-model":"o3"
+        "chat-model":"o3",
+        "O4":"gpt-4o"
       },
       "xai_grok":{
         "auth_key":"6768-insert-your-api-key-8768",
-        "model":"grok-3-mini-fast"
+        "model":"grok-3-mini-fast",
+        "42":"grok-4-2"
       },
       "ggl_gemini":{
         "auth_key":"6768-insert-your-api-key-8768",
         "model":"gemini-2.0-flash",
-        "chat-model":"gemini-2.0-flash"
+        "chat-model":"gemini-2.0-flash",
+        "35":"gemini-3.5-pro"
       },
       "deepseek":{
         "auth_key":"6768-insert-your-api-key-8768",
@@ -64,8 +67,10 @@
       },
       "ant_claude":{
         "auth_key":"6768-insert-your-api-key-8768",
-        "model":"claude-3-5-sonnet-20241022",
-        "chat-model":"claude-3-5-sonnet-20241022"
+        "model":"claude-haiku-4-5",
+        "chat-model":"claude-haiku-4-5",
+        "OP46":"claude-opus-4-6",
+        "SO46":"claude-sonnet-4-6"
       },
       "huggingface":{
         "auth_token":"hf_insert-your-api-token-here",

--- a/src/Flussu/Controllers/AiChatController.php
+++ b/src/Flussu/Controllers/AiChatController.php
@@ -53,16 +53,41 @@ class AiChatController
                 $this->_aiClient= new FlussuOpenAi($model,$chat_model);
                 $this->_linkify=0;
                 break;
+            case Platform::CHATGPT_O4:
+                $m = config("services.ai_provider.open_ai.O4") ?: $model;
+                $this->_aiClient= new FlussuOpenAi($m,$m);
+                $this->_linkify=0;
+                break;
             case Platform::GROK:
                 $this->_aiClient= new FlussuGrokAi($model);
+                $this->_linkify=0;
+                break;
+            case Platform::GROK_42:
+                $m = config("services.ai_provider.xai_grok.42") ?: $model;
+                $this->_aiClient= new FlussuGrokAi($m);
                 $this->_linkify=0;
                 break;
             case Platform::GEMINI:
                 $this->_aiClient= new FlussuGeminAi($model);
                 $this->_linkify=0;
                 break;
+            case Platform::GEMINI_35:
+                $m = config("services.ai_provider.ggl_gemini.35") ?: $model;
+                $this->_aiClient= new FlussuGeminAi($m);
+                $this->_linkify=0;
+                break;
             case Platform::CLAUDE:
                 $this->_aiClient= new FlussuClaudeAi($model);
+                $this->_linkify=1;
+                break;
+            case Platform::CLAUDE_OP46:
+                $m = config("services.ai_provider.ant_claude.OP46") ?: $model;
+                $this->_aiClient= new FlussuClaudeAi($m,$m);
+                $this->_linkify=1;
+                break;
+            case Platform::CLAUDE_SO46:
+                $m = config("services.ai_provider.ant_claude.SO46") ?: $model;
+                $this->_aiClient= new FlussuClaudeAi($m,$m);
                 $this->_linkify=1;
                 break;
             case Platform::DEEPSEEK:

--- a/src/Flussu/Controllers/AiMediaController.php
+++ b/src/Flussu/Controllers/AiMediaController.php
@@ -52,14 +52,34 @@ class AiMediaController
             case Platform::CHATGPT:
                 $this->_aiClient = new FlussuOpenAi($model, $chat_model);
                 break;
+            case Platform::CHATGPT_O4:
+                $m = config("services.ai_provider.open_ai.O4") ?: $model;
+                $this->_aiClient = new FlussuOpenAi($m, $m);
+                break;
             case Platform::GROK:
                 $this->_aiClient = new FlussuGrokAi($model);
+                break;
+            case Platform::GROK_42:
+                $m = config("services.ai_provider.xai_grok.42") ?: $model;
+                $this->_aiClient = new FlussuGrokAi($m);
                 break;
             case Platform::GEMINI:
                 $this->_aiClient = new FlussuGeminAi($model);
                 break;
+            case Platform::GEMINI_35:
+                $m = config("services.ai_provider.ggl_gemini.35") ?: $model;
+                $this->_aiClient = new FlussuGeminAi($m);
+                break;
             case Platform::CLAUDE:
                 $this->_aiClient = new FlussuClaudeAi($model);
+                break;
+            case Platform::CLAUDE_OP46:
+                $m = config("services.ai_provider.ant_claude.OP46") ?: $model;
+                $this->_aiClient = new FlussuClaudeAi($m, $m);
+                break;
+            case Platform::CLAUDE_SO46:
+                $m = config("services.ai_provider.ant_claude.SO46") ?: $model;
+                $this->_aiClient = new FlussuClaudeAi($m, $m);
                 break;
             case Platform::DEEPSEEK:
                 $this->_aiClient = new FlussuDeepSeekAi($model);

--- a/src/Flussu/Controllers/Platform.php
+++ b/src/Flussu/Controllers/Platform.php
@@ -19,10 +19,23 @@ namespace Flussu\Controllers;
 enum Platform: int {
     case INIT = -1;
     case CHATGPT = 0;
+    // --- CHATGPT model variants ---
+    case CHATGPT_O4 = 101;
+    //----------------------------------
     case GROK = 1;
+    // --- GROK model variants ---
+    case GROK_42 = 11;
+    //----------------------------------
     case GEMINI = 2;
+    // --- GEMINI model variants ---
+    case GEMINI_35 = 21;
+    //----------------------------------
     case DEEPSEEK = 3;
     case CLAUDE = 4;
+    // --- CLAUDE model variants ---
+    case CLAUDE_OP46 = 41;
+    case CLAUDE_SO46 = 42;
+    //----------------------------------
     case HUGGINGFACE = 5;
     case ZEROONE = 6;
     case KIMI = 7;


### PR DESCRIPTION
Extend Platform enum with model-specific variants using family-based numbering (e.g., CLAUDE=4, CLAUDE_OP46=41, CLAUDE_SO46=42). Each variant reads its model name from config, sharing the same auth_key and provider class as the base platform. Existing platform values unchanged.

New variants: CHATGPT_O4, GROK_42, GEMINI_35, CLAUDE_OP46, CLAUDE_SO46

https://claude.ai/code/session_01F2Cx444PDYmMAJpRmWPdEn